### PR TITLE
Add multi-project solution with F#

### DIFF
--- a/failing/Multi/MyAwesomeLibrary.CSharp/src/CSharp/Library.cs
+++ b/failing/Multi/MyAwesomeLibrary.CSharp/src/CSharp/Library.cs
@@ -1,0 +1,10 @@
+using System;
+using MyAwesomeLibrary.Core;
+
+namespace MyAwesomeLibrary.CSharp
+{
+    public static class Lib
+    {
+        public static string GetMessage(string name) => LibCore.GetMessage(name);
+    }
+}

--- a/failing/Multi/MyAwesomeLibrary.CSharp/src/CSharp/project.json
+++ b/failing/Multi/MyAwesomeLibrary.CSharp/src/CSharp/project.json
@@ -1,0 +1,11 @@
+{
+  "name":"MyAwesomeLibrary.CSharp",
+  "version": "1.0.0",
+  "dependencies": {
+    "MyAwesomeLibrary.Core":"1.0.0",
+    "NETStandard.Library": "1.5.0-rc2-24027"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/failing/Multi/MyAwesomeLibrary.CSharp/test/CSharp.Tests/Test.cs
+++ b/failing/Multi/MyAwesomeLibrary.CSharp/test/CSharp.Tests/Test.cs
@@ -1,0 +1,15 @@
+using System;
+using Xunit;
+using MyAwesomeLibrary.CSharp;
+
+namespace MyAwesomeLibrary.CSharp.Tests
+{
+    public class Tests
+    {
+        [Fact]
+        public void MessageTest()
+        {
+            Assert.Equal("Live long and prosper, Phillip", Lib.GetMessage("Phillip"));
+        }
+    }
+}

--- a/failing/Multi/MyAwesomeLibrary.CSharp/test/CSharp.Tests/project.json
+++ b/failing/Multi/MyAwesomeLibrary.CSharp/test/CSharp.Tests/project.json
@@ -1,0 +1,18 @@
+{
+  "testRunner": "xunit",
+  "dependencies":{
+    "MyAwesomeLibrary.CSharp":"1.0.0",
+    "Microsoft.NETCore.App": {
+        "type": "platform",
+        "version": "1.0.0-rc2-3002543"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [ "dotnet5.4", "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/failing/Multi/MyAwesomeLibrary.Core/src/Core/Core.cs
+++ b/failing/Multi/MyAwesomeLibrary.Core/src/Core/Core.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace MyAwesomeLibrary.Core
+{
+    public static class LibCore
+    {
+        public static string GetMessage(string name) => $"Live long and prosper, {name}";
+    }
+}

--- a/failing/Multi/MyAwesomeLibrary.Core/src/Core/project.json
+++ b/failing/Multi/MyAwesomeLibrary.Core/src/Core/project.json
@@ -1,0 +1,10 @@
+{
+  "name":"MyAwesomeLibrary.Core",
+  "version": "1.0.0",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-24027"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/failing/Multi/MyAwesomeLibrary.Core/test/Core.Tests/Test.cs
+++ b/failing/Multi/MyAwesomeLibrary.Core/test/Core.Tests/Test.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Xunit;
+using MyAwesomeLibrary.Core;
+
+namespace MyAwesomeLibrary.Core.Tests
+{
+    public class Tests
+    {
+        [Fact]
+        public void MessageTest()
+        {
+            Assert.Equal("Live long and prosper, Phillip", LibCore.GetMessage("Phillip"));
+        }
+    }
+}

--- a/failing/Multi/MyAwesomeLibrary.Core/test/Core.Tests/project.json
+++ b/failing/Multi/MyAwesomeLibrary.Core/test/Core.Tests/project.json
@@ -1,0 +1,18 @@
+{
+  "testRunner": "xunit",
+  "dependencies":{
+    "MyAwesomeLibrary.Core": "1.0.0",
+    "Microsoft.NETCore.App": {
+        "type": "platform",
+        "version": "1.0.0-rc2-3002543"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [ "dotnet5.4", "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/Library.fs
+++ b/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/Library.fs
@@ -1,0 +1,5 @@
+﻿open System
+open MyAwesomeLibrary.Core
+
+module Lib =
+    let GetMessage name = name |> LibCore.GetMessage

--- a/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/NuGet.Config
+++ b/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/NuGet.Config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+    
+     <!-- Location of dotnet-compile-fsc tool -->
+    <add key="dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
+    
+    <!-- Also needed !-->
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild" />
+  </packageSources>
+</configuration>

--- a/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/project.json
+++ b/failing/Multi/MyAwesomeLibrary.FSharp/src/FSharp/project.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "compilerName": "fsc",
+    "compile": {
+      "includeFiles": [
+        "Library.fs"
+      ]
+    }
+  },
+  "dependencies": {
+    "MyAwesomeLibrary.Core":"1.0.0",
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-3002700"
+    }
+  },
+  "tools": {
+    "dotnet-compile-fsc": {
+      "version": "1.0.0-*",
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win81",
+        "netstandard1.3"
+      ]
+    }
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "portable-net45+win8",
+        "dnxcore50"
+      ]
+    }
+  }
+}

--- a/failing/Multi/MyAwesomeLibrary.FSharp/test/FSharp.Tests/Test.cs
+++ b/failing/Multi/MyAwesomeLibrary.FSharp/test/FSharp.Tests/Test.cs
@@ -1,0 +1,15 @@
+using System;
+using Xunit;
+using MyAwesomeLibrary.FSharp;
+
+namespace MyAwesomeLibrary.FSharp.Tests
+{
+    public class Tests
+    {
+        [Fact]
+        public void MessageTest()
+        {
+            Assert.Equal("Live long and prosper, Phillip", Lib.GetMessage("Phillip"));
+        }
+    }
+}

--- a/failing/Multi/MyAwesomeLibrary.FSharp/test/FSharp.Tests/project.json
+++ b/failing/Multi/MyAwesomeLibrary.FSharp/test/FSharp.Tests/project.json
@@ -1,0 +1,18 @@
+{
+  "testRunner": "xunit",
+  "dependencies":{
+    "MyAwesomeLibrary.FSharp":"1.0.0",
+    "Microsoft.NETCore.App": {
+        "type": "platform",
+        "version": "1.0.0-rc2-3002543"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [ "dotnet5.4", "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/failing/Multi/NuGet.Config
+++ b/failing/Multi/NuGet.Config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/failing/Multi/global.json
+++ b/failing/Multi/global.json
@@ -1,0 +1,7 @@
+{
+	"projects": [
+		"MyAwesomeLibrary.Core",
+		"MyAwesomeLibrary.CSharp",
+		"MyAwesomeLibrary.FSharp"
+	]
+}


### PR DESCRIPTION
Here, dotnet restore will fail to resolve P2P dependencies and resolve the F# library as valid for netstandard1.5.
