### PR TITLE
This is fun!</sarcasm>

### DIFF
--- a/failing/p2prefseenasnet45/global.json
+++ b/failing/p2prefseenasnet45/global.json
@@ -1,3 +1,3 @@
-﻿{ "Projects":
+﻿{ "projects":
   ["src", "test"]
 }

--- a/failing/p2prefseenasnet45/test/testlibrary/project.json
+++ b/failing/p2prefseenasnet45/test/testlibrary/project.json
@@ -2,7 +2,10 @@
   "version": "1.0.0-*",
   "testRunner": "xunit",  
   "dependencies": {
-    "Library": "1.0.0-*",
+    "Library": {
+        "version": "1.0.0-*",
+        "target": "project"
+    },
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0-rc2-3002543"


### PR DESCRIPTION
The problem here was two-fold:
1. The "Library" reference was getting resolved from nuget.org from a test Library which only targets 4.5. When I changed the test's `project.json` to reference the Library as `"target": "project"` it started working. 
2. It still wouldn't restore because `global.json` had `Projects` and not `projects` in it.

So, two problems here:
1. NuGet prefers online package sources to local and that is not specified anywhere.
2. I don't think we have any docs that specify what is the proper/bulletproof way of referencing P2P references. 

/cc @cartermp @bleroy 
